### PR TITLE
Add "udevadm trigger" command for ST-Link udev updates

### DIFF
--- a/_posts/2020-06-16-Non-root_access_USB.md
+++ b/_posts/2020-06-16-Non-root_access_USB.md
@@ -81,6 +81,7 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3753", MODE="600"
 EOF
 
 sudo udevadm control --reload-rules
+sudo udevadm trigger
 ```
 
 ## USB-to-serial converters
@@ -144,4 +145,5 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="0557", ATTRS{idProduct}=="2008", MODE="600"
 EOF
 
 sudo udevadm control --reload-rules
+sudo udevadm trigger
 ```


### PR DESCRIPTION
This PR just adds `udevadm trigger` after `udevadm reload` in the ST-Link article.

`udevadm trigger` reloads all the rules for already-connected devices, without requiring the user to restart the system or re-plug the devices (see https://unix.stackexchange.com/questions/39370/how-to-reload-udev-rules-without-reboot for more information).